### PR TITLE
Update docker-cmd.sh

### DIFF
--- a/docker-cmd.sh
+++ b/docker-cmd.sh
@@ -13,6 +13,9 @@ fi
 cp "/usr/share/zoneinfo/$TZ" /etc/localtime
 echo "$TZ" > /etc/timezone
 
+#Make cgi-tmp directory before setting permissions
+mkdir /var/lib/munin/cgi-tmp
+
 # Fix ownership
 chown munin:munin \
   /var/log/munin /run/munin /var/lib/munin /var/lib/munin/cgi-tmp \


### PR DESCRIPTION
docker-cmd.sh tries to chown /var/lib/munin/cgi-tmp before it exists (on new installs).

make the directory first to fix this issue