### PR TITLE
Redirect `/` to `/munin/`

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -3,7 +3,7 @@ server {
     listen [::]:80 default_server;
 
     location / {
-        return 404;
+        return 301 /munin/;
     }
 
     location = /404.html {


### PR DESCRIPTION
Instead of returning a 404, perhaps it would be more helpful to redirect the user to the correct `/munin/` path.